### PR TITLE
Disconnect Bluetooth client after printing

### DIFF
--- a/catte.py
+++ b/catte.py
@@ -64,6 +64,7 @@ async def run():
             await client.write_gatt_char(char, buf, True)
             print(".", end="", flush=True)
         print(" Sent.")
+        await client.disconnect()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hey, thanks for the script!

I ran and tested it on a [pinephone](https://www.pine64.org/pinephone/) and was having issues with Bluetooth "turning off" after running. I think it has to do with the BleakClient timing out and not explicitly disconnecting. I added a line that does and now it seems to work fine.
